### PR TITLE
config v.27.06

### DIFF
--- a/src/ConfigParser.hpp
+++ b/src/ConfigParser.hpp
@@ -64,6 +64,7 @@ class ConfigParser
 
 	private:
 		std::vector<ServerConfig> _configServ;
+		std::vector<ListenStruct> _uniqueListen;
 
 		void parseConfigFile(std::string const & fileName );
 		ServerConfig parseServer(std::vector<std::string>& strs);
@@ -88,6 +89,7 @@ class ConfigParser
 		void checkPort(ServerConfig& serverData);
 		void defineDefaultListen(ServerConfig& serverData);
 		void defineDefaultMethods(LocationStruct& location);
+		void extractUniqueListen(void);
 };
 
 #endif


### PR DESCRIPTION
-Сделал удобный контейнер всех listen/port что бы при bind избегать ошибки с одинаковыми IP/PORT

extractUniqueListen(void)

_uniqueListen;


-Теперь при проверке дублирующих listen между серверами  разрешаем парсеру идти дальше если server_name разные ,если одинаковые то выводим ошибку конфигурации а так же если оба сервера не имеют server_name

validateGlobalUniqueListen
