### PR TITLE
MIME-type mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC      = g++
 FLAGS   = -Wall -Wextra -Werror -std=c++98
 SRCDIR  = ./src/
 OBJDIR  = $(SRCDIR)obj/
-SRCS    = server.cpp client.cpp HttpRequest.cpp HttpResponse.cpp webserv.cpp ConfigParser.cpp RequestHandler.cpp utils.cpp
+SRCS    = server.cpp client.cpp HttpRequest.cpp HttpResponse.cpp webserv.cpp ConfigParser.cpp RequestHandler.cpp utils.cpp MimeTypes.cpp
 OBJS    = $(addprefix $(OBJDIR), $(SRCS:.cpp=.o)) 
 RM      = rm -f
 

--- a/src/MimeTypes.cpp
+++ b/src/MimeTypes.cpp
@@ -1,0 +1,41 @@
+#include "MimeTypes.hpp"
+
+const std::map<std::string, std::string>& getMimeTypes()
+{
+    static std::map<std::string, std::string> mime;
+    if (mime.empty())
+    {
+        mime[".html"] = "text/html";
+        mime[".htm"] = "text/html";
+        mime[".css"] = "text/css";
+        mime[".js"] = "application/javascript";
+        mime[".json"] = "application/json";
+        mime[".xml"] = "application/xml";
+        mime[".txt"] = "text/plain";
+        mime[".png"] = "image/png";
+        mime[".jpg"] = "image/jpeg";
+        mime[".jpeg"] = "image/jpeg";
+        mime[".gif"] = "image/gif";
+        mime[".ico"] = "image/x-icon";
+        mime[".svg"] = "image/svg+xml";
+        mime[".webp"] = "image/webp";
+        mime[".bmp"] = "image/bmp";
+        mime[".mp4"] = "video/mp4";
+        mime[".mpeg"] = "video/mpeg";
+        mime[".mp3"] = "audio/mpeg";
+        mime[".wav"] = "audio/wav";
+        mime[".ogg"] = "audio/ogg";
+        mime[".woff"] = "font/woff";
+        mime[".woff2"] = "font/woff2";
+        mime[".ttf"] = "font/ttf";
+        mime[".otf"] = "font/otf";
+        mime[".eot"] = "application/vnd.ms-fontobject";
+        mime[".zip"] = "application/zip";
+        mime[".tar"] = "application/x-tar";
+        mime[".gz"] = "application/gzip";
+        mime[".pdf"] = "application/pdf";
+        mime[".csv"] = "text/csv";
+    }
+    return mime;
+}
+

--- a/src/MimeTypes.hpp
+++ b/src/MimeTypes.hpp
@@ -1,0 +1,9 @@
+#ifndef MIMETYPES_HPP
+#define MIMETYPES_HPP
+
+#include <map>
+#include <string>
+
+const std::map<std::string, std::string>& getMimeTypes();
+
+#endif

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -1,6 +1,7 @@
 #include "RequestHandler.hpp"
 #include "ConfigParser.hpp"
 #include "utils.hpp"
+#include "MimeTypes.hpp"
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -170,8 +171,13 @@ HttpResponse RequestHandler::_handleGet(const HttpRequest &request, const Locati
 
     HttpResponse response;
     response.setStatusCode(200);
-    // TODO:
-    response.addHeader("Content-Type", "text/plain"); // Миш, я тут хз как определять MIME-тип. Пока хардкод
+    size_t pos = absPath.find_last_of(".");
+    std::string ext = (pos != std::string::npos) ? absPath.substr(pos) : "";
+    const std::map<std::string, std::string>& mimes = getMimeTypes();
+    std::string mime = "application/octet-stream";
+    if (mimes.count(ext))
+        mime = mimes.at(ext);
+    response.addHeader("Content-Type", mime);
     response.setBody(body);
     return response;
 }


### PR DESCRIPTION
## Summary
- define `getMimeTypes` function with common extensions
- expose declaration in `MimeTypes.hpp`
- use MIME map in `RequestHandler` for GET responses
- compile `MimeTypes.cpp` via Makefile

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685fd453dbf8832cae2b978d6c0b7e91