### PR TITLE
Implement canonical form for HTTP classes

### DIFF
--- a/src/HttpRequest.cpp
+++ b/src/HttpRequest.cpp
@@ -48,10 +48,30 @@ static std::string decodeChunked(const std::string &in)
     return out;
 }
 
+HttpRequest::HttpRequest() {}
+
+HttpRequest::HttpRequest(const HttpRequest &src)
+{
+    *this = src;
+}
+
 HttpRequest::HttpRequest(const std::string &raw_request)
 {
 
     _parse(raw_request);
+}
+
+HttpRequest &HttpRequest::operator=(const HttpRequest &src)
+{
+    if (this != &src)
+    {
+        _method = src._method;
+        _uri = src._uri;
+        _http_version = src._http_version;
+        _headers = src._headers;
+        _body = src._body;
+    }
+    return *this;
 }
 
 HttpRequest::~HttpRequest() {}

--- a/src/HttpRequest.hpp
+++ b/src/HttpRequest.hpp
@@ -12,7 +12,10 @@
 class HttpRequest
 {
 public:
+    HttpRequest();
+    HttpRequest(const HttpRequest &src);
     HttpRequest(const std::string &raw_request);
+    HttpRequest &operator=(const HttpRequest &src);
     ~HttpRequest();
 
     std::string getMethod() const;

--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -2,6 +2,23 @@
 #include <sstream>
 
 HttpResponse::HttpResponse() : _statusCode(200), _statusMessage("OK") {}
+
+HttpResponse::HttpResponse(const HttpResponse &src)
+{
+    *this = src;
+}
+
+HttpResponse &HttpResponse::operator=(const HttpResponse &src)
+{
+    if (this != &src)
+    {
+        _statusCode = src._statusCode;
+        _statusMessage = src._statusMessage;
+        _headers = src._headers;
+        _body = src._body;
+    }
+    return *this;
+}
 HttpResponse::~HttpResponse() {}
 
 void HttpResponse::setStatusMessage(const std::string& message) { _statusMessage = message; }

--- a/src/HttpResponse.hpp
+++ b/src/HttpResponse.hpp
@@ -9,6 +9,8 @@ class HttpResponse
 {
 public:
     HttpResponse();
+    HttpResponse(const HttpResponse &src);
+    HttpResponse &operator=(const HttpResponse &src);
     ~HttpResponse();
 
     void setStatusCode(int code);

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -10,7 +10,23 @@
 #include <cstdlib>
 #include <cctype>
 
-RequestHandler::RequestHandler(ConfigParser &config) : _config(config) {}
+RequestHandler::RequestHandler() : _config(NULL) {}
+
+RequestHandler::RequestHandler(ConfigParser &config) : _config(&config) {}
+
+RequestHandler::RequestHandler(const RequestHandler &src)
+{
+    *this = src;
+}
+
+RequestHandler &RequestHandler::operator=(const RequestHandler &src)
+{
+    if (this != &src)
+    {
+        _config = src._config;
+    }
+    return *this;
+}
 
 RequestHandler::~RequestHandler() {}
 
@@ -351,7 +367,9 @@ HttpResponse RequestHandler::_createErrorResponse(int statusCode, const ServerCo
 
 const ServerConfig *RequestHandler::_findServerConfig(int port, const std::string &host) const
 {
-    const std::vector<ServerConfig> &servers = _config.getServers(); // Миш, мне тут нужен геттер типа return this->_configServ
+    if (!_config)
+        return NULL;
+    const std::vector<ServerConfig> &servers = _config->getServers(); // Миш, мне тут нужен геттер типа return this->_configServ
     const ServerConfig *default_server_for_port = NULL;
 
     for (size_t i = 0; i < servers.size(); ++i)

--- a/src/RequestHandler.hpp
+++ b/src/RequestHandler.hpp
@@ -7,13 +7,16 @@
 
 class RequestHandler {
 public:
+    RequestHandler();
     RequestHandler(ConfigParser& config);
+    RequestHandler(const RequestHandler& src);
+    RequestHandler& operator=(const RequestHandler& src);
     ~RequestHandler();
 
     HttpResponse handleRequest(const HttpRequest& request, int serverPort, const std::string& serverHost);
 
 private:
-    ConfigParser& _config; 
+    ConfigParser* _config;
 
     HttpResponse _handleGet(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);
     HttpResponse _handlePost(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);


### PR DESCRIPTION
## Summary
- add default/copy constructors and assignment operators to `HttpRequest`
- implement canonical form methods in `HttpResponse`
- redesign `RequestHandler` to use a pointer and provide canonical form
- keep build passing with these updates

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6871160f9650832cb2e9e30cb7a55bdc