### PR TITLE
Add multipart/form-data POST support

### DIFF
--- a/src/RequestHandler.hpp
+++ b/src/RequestHandler.hpp
@@ -5,6 +5,12 @@
 #include "HttpResponse.hpp"
 #include "ConfigParser.hpp"
 
+struct MultipartPart {
+    std::string name;
+    std::string filename;
+    std::string body;
+};
+
 class RequestHandler {
 public:
     RequestHandler();
@@ -20,6 +26,10 @@ private:
 
     HttpResponse _handleGet(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);
     HttpResponse _handlePost(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);
+    HttpResponse _handleSimplePost(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);
+    HttpResponse _handleMultipart(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);
+    std::string saveBodyToFile(const std::string& body, const std::string& suggestedName,
+                               const LocationStruct& location, const ServerConfig& server);
     HttpResponse _handleDelete(const HttpRequest& request, const LocationStruct& location, const ServerConfig& server);
 
     HttpResponse _createErrorResponse(int statusCode, const ServerConfig* server, const std::vector<std::string>* allowed_methods = NULL);


### PR DESCRIPTION
## Summary
- support POST multipart form uploads
- refactor file-saving logic
- expose helpers to parse multipart bodies

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_687fcef5dd6c832c99381d211faeec4a