### PR TITLE
Add redirect support

### DIFF
--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -32,6 +32,8 @@ std::map<int, std::string> HttpResponse::initStatusMessages()
     m[200] = "OK";
     m[201] = "Created";
     m[204] = "No Content";
+    m[301] = "Moved Permanently";
+    m[302] = "Found";
     m[400] = "Bad Request";
     m[404] = "Not Found";
     m[405] = "Method Not Allowed";

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -146,6 +146,19 @@ HttpResponse RequestHandler::handleRequest(const HttpRequest &request, int serve
             return _createErrorResponse(404, server_config, NULL);
         }
 
+        // После поиска подходящего location — проверяем, нужно ли делать редирект
+        if (!location_config->redir.empty())
+        {
+            // Берём код и URL из конфига
+            int code = location_config->redir.begin()->first;
+            std::string url = location_config->redir.begin()->second;
+            // Формируем ответ-редирект
+            HttpResponse res;
+            res.setStatusCode(code);
+            res.addHeader("Location", url);
+            return res;
+        }
+
         // Проверяем, 413
 
         size_t limit_in_bytes = location_config->client_max_body_size;


### PR DESCRIPTION
## Summary
- include standard HTTP redirect messages in status table
- return redirect responses according to location config

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68891ffaa9ac832cb0720053acef2f97