### PR TITLE
Refactor upload directory logic

### DIFF
--- a/src/RequestHandler.hpp
+++ b/src/RequestHandler.hpp
@@ -36,8 +36,11 @@ private:
     HttpResponse _handleSimplePost(const HttpRequest &request, const LocationStruct &location, const ServerConfig &server);
     HttpResponse _handleMultipart(const HttpRequest &request, const LocationStruct &location, const ServerConfig &server);
     std::string saveBodyToFile(const std::string &body, const std::string &suggestedName,
-                               const LocationStruct &location, const ServerConfig &server);
+                               const std::string &storageDir);
     HttpResponse _handleDelete(const HttpRequest &request, const LocationStruct &location, const ServerConfig &server);
+
+    // Returns the absolute directory to use for file uploads or an empty string on error
+    std::string _getStorageDir(const LocationStruct &location, const ServerConfig &server) const;
 
     HttpResponse _createErrorResponse(int statusCode, const ServerConfig *server, const std::vector<std::string> *allowed_methods, const LocationStruct *location = NULL);
 };


### PR DESCRIPTION
## Summary
- centralize storage directory resolution in RequestHandler
- update POST and DELETE handlers to use new helper
- simplify saveBodyToFile interface

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6889fccc4e28832c8fdf3c7bc6f398f2