### PR TITLE
Add header and URI size limits

### DIFF
--- a/src/HttpRequest.cpp
+++ b/src/HttpRequest.cpp
@@ -61,6 +61,13 @@ HttpRequest::~HttpRequest() {}
 
 void HttpRequest::_parse(const std::string &raw_request)
 {
+    static const size_t MAX_HEADER_SIZE = 8192;
+    size_t header_end = raw_request.find("\r\n\r\n");
+    if (header_end == std::string::npos)
+        throw std::runtime_error("400 Bad Request");
+    if (header_end > MAX_HEADER_SIZE)
+        throw std::runtime_error("431 Request Header Fields Too Large");
+
     std::stringstream request_stream(raw_request);
 
     _parseRequestLine(request_stream);

--- a/src/HttpRequest.cpp
+++ b/src/HttpRequest.cpp
@@ -79,6 +79,7 @@ void HttpRequest::_parse(const std::string &raw_request)
 
 void HttpRequest::_parseRequestLine(std::stringstream &request_stream)
 {
+    static const size_t MAX_URI_LENGTH = 8192;
     std::string request_line;
     if (!std::getline(request_stream, request_line) || request_line.empty())
     {
@@ -96,6 +97,9 @@ void HttpRequest::_parseRequestLine(std::stringstream &request_stream)
     {
         throw std::runtime_error("400 Bad Request: Malformed request line. Expected 'METHOD URI VERSION'");
     }
+
+    if (rawUri.size() > MAX_URI_LENGTH)
+        throw std::runtime_error("414 URI Too Long");
 
     // Если клиент прислал абсолютный URI ("http://host[:port]/path"), обрезаем до "/path"
     if (rawUri.rfind("http://", 0) == 0 || rawUri.rfind("https://", 0) == 0)

--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -37,6 +37,8 @@ std::map<int, std::string> HttpResponse::initStatusMessages()
     m[400] = "Bad Request";
     m[404] = "Not Found";
     m[405] = "Method Not Allowed";
+    m[414] = "URI Too Long";
+    m[431] = "Request Header Fields Too Large";
     m[413] = "Payload Too Large";
     m[500] = "Internal Server Error";
     m[501] = "Not Implemented";

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -121,6 +121,15 @@ RequestHandler &RequestHandler::operator=(const RequestHandler &src)
 
 RequestHandler::~RequestHandler() {}
 
+HttpResponse RequestHandler::createErrorResponse(int statusCode,
+                                                const ServerConfig *server,
+                                                const std::vector<std::string> *allowed_methods,
+                                                const LocationStruct *location)
+{
+    RequestHandler tmp;
+    return tmp._createErrorResponse(statusCode, server, allowed_methods, location);
+}
+
 HttpResponse RequestHandler::handleRequest(const HttpRequest &request, int serverPort, const std::string &serverIp, const std::string &serverHost)
 {
 

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -127,6 +127,12 @@ HttpResponse RequestHandler::handleRequest(const HttpRequest &request, int serve
     const ServerConfig *server_config = NULL;
     const LocationStruct *location_config = NULL;
 
+    static const size_t MAX_URI_LENGTH = 8192;
+    if (request.getUri().size() > MAX_URI_LENGTH)
+    {
+        return _createErrorResponse(414, server_config, NULL, location_config);
+    }
+
     try
     {
         server_config = _findServerConfig(serverPort, serverIp, serverHost);

--- a/src/RequestHandler.hpp
+++ b/src/RequestHandler.hpp
@@ -24,6 +24,12 @@ public:
 
     HttpResponse handleRequest(const HttpRequest &request, int serverPort, const std::string &serverIp, const std::string &serverHost);
 
+    // Utility to create standardized error responses outside of handleRequest
+    static HttpResponse createErrorResponse(int statusCode,
+                                            const ServerConfig *server = NULL,
+                                            const std::vector<std::string> *allowed_methods = NULL,
+                                            const LocationStruct *location = NULL);
+
 protected:
     const ServerConfig* _findServerConfig(int port, const std::string& ip, const std::string& host) const;
     const LocationStruct* _findLocationFor(const ServerConfig& server, const std::string& uri) const;


### PR DESCRIPTION
## Summary
- enforce a maximum header section size during request parsing
- reject over-long URIs before processing a request

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688a0658c704832c99a6ef7a243c292a